### PR TITLE
Retain focus when originally focused editor was removed

### DIFF
--- a/lib/view.coffee
+++ b/lib/view.coffee
@@ -158,7 +158,9 @@ class View extends SelectListView
 
     # HACK When no focusable item was exists on workspace, focus tree-view for
     # somooth keyboard navigation.
-    unless @hasItemInWorkspace()
+    if atom.workspace.getCenter().getPaneItems().length
+      atom.workspace.getActivePane().activate()
+    else
       workspaceElement = atom.views.getView(atom.workspace)
       atom.commands.dispatch(workspaceElement, 'tree-view:toggle-focus')
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/t9md/atom-project-folder",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": "^1.18.0"
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.5",


### PR DESCRIPTION
- When `closeItemsForRemovedProject` config was enabled
- `replace` or `remove` destroy editor belongs to removed project's.
- In that case user lost focus, lost ability to keyboard navigtion, need mouse click to focus some pane. this is super bad.
- AFAIR This was not issue before dock/workspace-center concept was introduced. from v.1.18?

This PR fix above issue by explicitly activate Pane(on cancel timing) to regain focus.
