### PR TITLE
Replace Underscore with Lodash

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-const _ = require("underscore-plus")
+const escapeRegExp = require("lodash.escaperegexp")
 const {normalize, getHomeDirectory, isDirectorySync, listSync, traverseTreeSync} = require("fs-plus")
 const Path = require("path")
 
@@ -12,7 +12,7 @@ function isGitRepository(dir) {
   return isDirectorySync(Path.join(dir, ".git"))
 }
 
-const HOME_DIRECTORY_REGEX = new RegExp(`^${_.escapeRegExp(getHomeDirectory())}`)
+const HOME_DIRECTORY_REGEX = new RegExp(`^${escapeRegExp(getHomeDirectory())}`)
 function tildifyHomeDirectory(dir) {
   return dir.replace(HOME_DIRECTORY_REGEX, "~")
 }

--- a/lib/view.js
+++ b/lib/view.js
@@ -1,5 +1,8 @@
 const {SelectListView, $, $$} = require("atom-space-pen-views")
-const _ = require("underscore-plus")
+const uniq = require("lodash.uniq")
+const reject = require("lodash.reject")
+const without = require("lodash.without")
+const isEqual = require("lodash.isequal")
 const CSON = require("season")
 const {normalize, isDirectorySync, existsSync} = require("fs-plus")
 const Path = require("path")
@@ -84,10 +87,10 @@ module.exports = class View extends SelectListView {
 
     if (this.action === "add") {
       groups = this.getItemsForGroups()
-      dirs = _.uniq([...this.getNormalDirectories(), ...this.getGitDirectories()])
+      dirs = uniq([...this.getNormalDirectories(), ...this.getGitDirectories()])
       if (settings.get("hideLoadedFolderFromAddList")) {
-        groups = _.reject(groups, allGroupMemberIsLoaded)
-        dirs = _.reject(dirs, isInProjectList)
+        groups = reject(groups, allGroupMemberIsLoaded)
+        dirs = reject(dirs, isInProjectList)
       }
     } else if (this.action === "remove") {
       const condition = settings.get("showGroupOnRemoveListCondition")
@@ -155,7 +158,7 @@ module.exports = class View extends SelectListView {
     this.list.find("li").each((i, element) => {
       const view = $(element)
       const viewItem = view.data("select-list-item")
-      const modelExists = this.items.some(item => _.isEqual(item, viewItem))
+      const modelExists = this.items.some(item => isEqual(item, viewItem))
 
       if (!modelExists) {
         if (view.hasClass("selected")) this.selectNextItemView()
@@ -222,7 +225,7 @@ module.exports = class View extends SelectListView {
     if (!item) return
 
     this.add(...item.dirs)
-    this.remove(..._.without(atom.project.getPaths(), ...item.dirs))
+    this.remove(...without(atom.project.getPaths(), ...item.dirs))
     this.cancel()
   }
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,12 @@
     "atom-space-pen-views": "^2.2.0",
     "fs-plus": "^2.10.1",
     "fuzzaldrin": "^2.1.0",
-    "season": "^5.4.1",
-    "underscore-plus": "^1.6.6"
+    "lodash.escaperegexp": "^4.1.2",
+    "lodash.isequal": "^4.5.0",
+    "lodash.reject": "^4.6.0",
+    "lodash.uniq": "^4.5.0",
+    "lodash.without": "^4.4.0",
+    "season": "^5.4.1"
   },
   "devDependencies": {
     "fs-extra": "^2.0.0",


### PR DESCRIPTION
This pull request replaces Underscore with Lodash. This means we don't have to install the entire `underscore-plus` package and instead we can install the specific functions we need from Lodash.